### PR TITLE
Tweak Esperanto translation’s capitalization

### DIFF
--- a/locale/carpets.eo.tr
+++ b/locale/carpets.eo.tr
@@ -3,18 +3,18 @@
 
 ### init.lua ###
 
-Black Carpet=Nigra Tapiŝo
-Blue Carpet=Blua Tapiŝo
-Brown Carpet=Bruna Tapiŝo
-Cyan Carpet=Bluverda Tapiŝo
-Dark Green Carpet=Malhela Verda Tapiŝo
-Dark Grey Carpet=Malhela Griza Tapiŝo
-Green Carpet=Verda Tapiŝo
-Grey Carpet=Griza Tapiŝo
-Magenta Carpet=Fuksina Tapiŝo
-Orange Carpet=Oranĝa Tapiŝo
-Pink Carpet=Rozkolora Tapiŝo
-Red Carpet=Ruĝa Tapiŝo
-Violet Carpet=Violkolora Tapiŝo
-White Carpet=Blanka Tapiŝo
-Yellow Carpet=Flava Tapiŝo
+Black Carpet=Nigra tapiŝo
+Blue Carpet=Blua tapiŝo
+Brown Carpet=Bruna tapiŝo
+Cyan Carpet=Bluverda tapiŝo
+Dark Green Carpet=Malhela verda tapiŝo
+Dark Grey Carpet=Malhela griza tapiŝo
+Green Carpet=Verda tapiŝo
+Grey Carpet=Griza tapiŝo
+Magenta Carpet=Fuksina tapiŝo
+Orange Carpet=Oranĝa tapiŝo
+Pink Carpet=Rozkolora tapiŝo
+Red Carpet=Ruĝa tapiŝo
+Violet Carpet=Violkolora tapiŝo
+White Carpet=Blanka tapiŝo
+Yellow Carpet=Flava tapiŝo


### PR DESCRIPTION
Replaces use of use capitals in item names, to agree with the Minetest game translation (which [now uses](https://github.com/minetest/minetest_game/pull/3092/commits/30b0a6cff0fdd86c2a2d95b5b392525075ecba6c) lowercase in titlecase). ^ ^