### PR TITLE
[NO SQUASH] Add several languages and follow MT naming standard

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -29,7 +29,7 @@ function carpets.register(material, def)
 	end
 
 	local material_def = minetest.registered_nodes[material]
-	node.description = node.description or material_def.description.." Carpet"
+	node.description = node.description or material_def.description.." carpet"
 	node.sounds = table.copy(node.sounds or material_def.sounds or default.node_sound_defaults())
 	node.groups = table.copy(node.groups)
 

--- a/init.lua
+++ b/init.lua
@@ -4,21 +4,21 @@ dofile(modpath .. "/api.lua")
 
 if minetest.get_modpath("wool") then
 	local nodes = {
-		{name="wool:black", description=S("Black Carpet")},
-		{name="wool:blue", description=S("Blue Carpet")},
-		{name="wool:brown", description=S("Brown Carpet")},
-		{name="wool:cyan", description=S("Cyan Carpet")},
-		{name="wool:dark_green", description=S("Dark Green Carpet")},
-		{name="wool:dark_grey", description=S("Dark Grey Carpet")},
-		{name="wool:green", description=S("Green Carpet")},
-		{name="wool:grey", description=S("Grey Carpet")},
-		{name="wool:magenta", description=S("Magenta Carpet")},
-		{name="wool:orange", description=S("Orange Carpet")},
-		{name="wool:pink", description=S("Pink Carpet")},
-		{name="wool:red", description=S("Red Carpet")},
-		{name="wool:violet", description=S("Violet Carpet")},
-		{name="wool:white", description=S("White Carpet")},
-		{name="wool:yellow", description=S("Yellow Carpet")},
+		{name="wool:black", description=S("Black carpet")},
+		{name="wool:blue", description=S("Blue carpet")},
+		{name="wool:brown", description=S("Brown carpet")},
+		{name="wool:cyan", description=S("Cyan carpet")},
+		{name="wool:dark_green", description=S("Dark Green carpet")},
+		{name="wool:dark_grey", description=S("Dark Grey carpet")},
+		{name="wool:green", description=S("Green carpet")},
+		{name="wool:grey", description=S("Grey carpet")},
+		{name="wool:magenta", description=S("Magenta carpet")},
+		{name="wool:orange", description=S("Orange carpet")},
+		{name="wool:pink", description=S("Pink carpet")},
+		{name="wool:red", description=S("Red carpet")},
+		{name="wool:violet", description=S("Violet carpet")},
+		{name="wool:white", description=S("White carpet")},
+		{name="wool:yellow", description=S("Yellow carpet")},
 	}
 	for _, node in ipairs(nodes) do
 		carpets.register(node.name, {description=node.description})

--- a/locale/carpets.de.tr
+++ b/locale/carpets.de.tr
@@ -1,0 +1,18 @@
+# textdomain: carpets
+
+##[ init.lua ]##
+Black carpet=Schwarzer Teppich
+Blue carpet=Blauer Teppich
+Brown carpet=Brauner Teppich
+Cyan carpet=Türkiser Teppich
+Dark green carpet=Dunkelgrüner Teppich
+Dark grey carpet=Dunkelgrauer Teppich
+Green carpet=Grüner Teppich
+Grey carpet=Grauer Teppich
+Magenta carpet=Magenta Teppich
+Orange carpet=Orange Teppich
+Pink carpet=Rosa Teppich
+Red carpet=Roter Teppich
+Violet carpet=Violetter Teppich
+White carpet=Weißer Teppich
+Yellow carpet=Gelber Teppich

--- a/locale/carpets.eo.tr
+++ b/locale/carpets.eo.tr
@@ -1,20 +1,18 @@
 # textdomain: carpets
 
-
-### init.lua ###
-
-Black Carpet=Nigra tapiŝo
-Blue Carpet=Blua tapiŝo
-Brown Carpet=Bruna tapiŝo
-Cyan Carpet=Bluverda tapiŝo
-Dark Green Carpet=Malhela verda tapiŝo
-Dark Grey Carpet=Malhela griza tapiŝo
-Green Carpet=Verda tapiŝo
-Grey Carpet=Griza tapiŝo
-Magenta Carpet=Fuksina tapiŝo
-Orange Carpet=Oranĝa tapiŝo
-Pink Carpet=Rozkolora tapiŝo
-Red Carpet=Ruĝa tapiŝo
-Violet Carpet=Violkolora tapiŝo
-White Carpet=Blanka tapiŝo
-Yellow Carpet=Flava tapiŝo
+##[ init.lua ]##
+Black carpet=Nigra tapiŝo
+Blue carpet=Blua tapiŝo
+Brown carpet=Bruna tapiŝo
+Cyan carpet=Bluverda tapiŝo
+Dark Green carpet=Malhela verda tapiŝo
+Dark Grey carpet=Malhela griza tapiŝo
+Green carpet=Verda tapiŝo
+Grey carpet=Griza tapiŝo
+Magenta carpet=Fuksina tapiŝo
+Orange carpet=Oranĝa tapiŝo
+Pink carpet=Rozkolora tapiŝo
+Red carpet=Ruĝa tapiŝo
+Violet carpet=Violkolora tapiŝo
+White carpet=Blanka tapiŝo
+Yellow carpet=Flava tapiŝo

--- a/locale/carpets.es.tr
+++ b/locale/carpets.es.tr
@@ -1,0 +1,18 @@
+# textdomain: carpets
+
+##[ init.lua ]##
+Black carpet=Alfombra negra
+Blue carpet=Alfombra azul
+Brown carpet=Alfombra marrón
+Cyan carpet=Alfombra cian
+Dark green carpet=Alfombra verde oscuro
+Dark grey carpet=Alfombra gris oscuro
+Green carpet=Alfombra verde
+Grey carpet=Alfombra gris
+Magenta carpet=Alfombra magenta
+Orange carpet=Alfombra naranja
+Pink carpet=Alfombra rosa
+Red carpet=Alfombra roja
+Violet carpet=Alfombra violeta
+White carpet=Alfombra blanca
+Yellow carpet=Alfombra amarilla

--- a/locale/carpets.fr.tr
+++ b/locale/carpets.fr.tr
@@ -1,20 +1,18 @@
 # textdomain: carpets
 
-
-### init.lua ###
-
-Black Carpet=Tapis noir
-Blue Carpet=Tapis bleu
-Brown Carpet=Tapis marron
-Cyan Carpet=Tapis cyan
-Dark Green Carpet=Tapis vert foncé
-Dark Grey Carpet=Tapis gris foncé
-Green Carpet=Tapis vert
-Grey Carpet=Tapis gris
-Magenta Carpet=Tapis magenta
-Orange Carpet=Tapis orange
-Pink Carpet=Tapis rose
-Red Carpet=Tapis rouge
-Violet Carpet=Tapis violet
-White Carpet=Tapis blanc
-Yellow Carpet=Tapis jaune
+##[ init.lua ]##
+Black carpet=Tapis noir
+Blue carpet=Tapis bleu
+Brown carpet=Tapis marron
+Cyan carpet=Tapis cyan
+Dark Green carpet=Tapis vert foncé
+Dark Grey carpet=Tapis gris foncé
+Green carpet=Tapis vert
+Grey carpet=Tapis gris
+Magenta carpet=Tapis magenta
+Orange carpet=Tapis orange
+Pink carpet=Tapis rose
+Red carpet=Tapis rouge
+Violet carpet=Tapis violet
+White carpet=Tapis blanc
+Yellow carpet=Tapis jaune

--- a/locale/carpets.hu.tr
+++ b/locale/carpets.hu.tr
@@ -1,0 +1,18 @@
+# textdomain: carpets
+
+##[ init.lua ]##
+Black carpet=Fekete szőnyeg
+Blue carpet=Kék szőnyeg
+Brown carpet=Barna szőnyeg
+Cyan carpet=Égszínkék szőnyeg
+Dark green carpet=Sötétzöld szőnyeg
+Dark grey carpet=Sötétszürke szőnyeg
+Green carpet=Zöld szőnyeg
+Grey carpet=Szürke szőnyeg
+Magenta carpet=Magenta szőnyeg
+Orange carpet=Narancs szőnyeg
+Pink carpet=Rózsaszín szőnyeg
+Red carpet=Piros szőnyeg
+Violet carpet=Lila szőnyeg
+White carpet=Fehér szőnyeg
+Yellow carpet=Sárga szőnyeg

--- a/locale/carpets.it.tr
+++ b/locale/carpets.it.tr
@@ -1,0 +1,18 @@
+# textdomain: carpets
+
+##[ init.lua ]##
+Black carpet=Tappeto nero
+Blue carpet=Tappeto blu
+Brown carpet=Tappeto marrone
+Cyan carpet=Tappero ciano
+Dark green carpet=Tappeto verde scuro
+Dark grey carpet=Tappeto grigio scuro
+Green carpet=Tappeto verde
+Grey carpet=Tappeto grigio
+Magenta carpet=Tappeto magenta
+Orange carpet=Tappeto arancione
+Pink carpet=Tappeto rosa
+Red carpet=Tappero rosso
+Violet carpet=Tappeto viola
+White carpet=Tappeto bianco
+Yellow carpet=Tappeto giallo

--- a/locale/carpets.pl.tr
+++ b/locale/carpets.pl.tr
@@ -1,0 +1,18 @@
+# textdomain: carpets
+
+##[ init.lua ]##
+Black carpet=Czarny dywan
+Blue carpet=Niebieski dywan
+Brown carpet=Brązowy dywan
+Cyan carpet=Błękitny dywan
+Dark green carpet=Ciemnozielony dywan
+Dark grey carpet=Ciemnoszary dywan
+Green carpet=Zielony dywan
+Grey carpet=Szary dywan
+Magenta carpet=Purpurowy dywan
+Orange carpet=Pomarańczowy dywan
+Pink carpet=Różowy dywan
+Red carpet=Czerwony dywan
+Violet carpet=Fioletowy dywan
+White carpet=Biały dywan
+Yellow carpet=Żółty dywan

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -1,20 +1,18 @@
 # textdomain: carpets
 
-
-### init.lua ###
-
-Black Carpet=
-Blue Carpet=
-Brown Carpet=
-Cyan Carpet=
-Dark Green Carpet=
-Dark Grey Carpet=
-Green Carpet=
-Grey Carpet=
-Magenta Carpet=
-Orange Carpet=
-Pink Carpet=
-Red Carpet=
-Violet Carpet=
-White Carpet=
-Yellow Carpet=
+##[ init.lua ]##
+Black carpet=
+Blue carpet=
+Brown carpet=
+Cyan carpet=
+Dark Green carpet=
+Dark Grey carpet=
+Green carpet=
+Grey carpet=
+Magenta carpet=
+Orange carpet=
+Pink carpet=
+Red carpet=
+Violet carpet=
+White carpet=
+Yellow carpet=


### PR DESCRIPTION
First commit: since MTG items are "Uppercase lowercase", I've converted the current strings ("Upper Upper") into the upper-lower standard.

Translation commits come from our custom mod "aes-decoblocks", which uses carpets https://gitlab.com/zughy-friends-minetest/a.e.s.-server-custom-mods/a.e.s.-decoblocks/-/tree/master/locale